### PR TITLE
Use YubiCloud validation protocol version 2.0.

### DIFF
--- a/libykclient.c
+++ b/libykclient.c
@@ -213,7 +213,7 @@ yubikey_client_request (yubikey_client_t client,
 {
   struct MemoryStruct chunk = { NULL, 0 };
   yubiauth_dir_cfg *cfg = ap_get_module_config(r->per_dir_config, &authn_yubikey_module);
-  const char *url_template = "%s://%s/wsapi/verify?id=%d&otp=%s";
+  const char *url_template = "%s://%s/wsapi/2.0/verify?id=%d&otp=%s&nonce=1234567890abcdef";
   char *url;
   char *user_agent = NULL;
   char *status;


### PR DESCRIPTION
The old YubiCloud v1 protocol is deprecated from 2018-12-10 (50% of
matching traffic will be rejected with an HTTP 410 response status),
and rejected from 2019-02-04 (all requests rejected):
https://status.yubico.com/2018/11/26/deprecating-yubicloud-v1-protocol-plain-text-requests-and-old-tls-versions/

This fix makes minimal changes to ensure that mod_authn_yubikey sends
requests following the v2.0 protocol:
https://developers.yubico.com/yubikey-val/Validation_Protocol_V2.0.html